### PR TITLE
Expand Shopify theme skeleton

### DIFF
--- a/theme/README.md
+++ b/theme/README.md
@@ -1,0 +1,10 @@
+# Shopify Theme
+
+This directory provides a minimal Shopify theme generated from the static HTML.
+
+To use it:
+1. Zip the `theme` directory contents.
+2. Upload the zip file in your Shopify admin as a new theme.
+
+The layout now uses separate header and footer sections and simple templates for
+products, collections, blogs, and pages.

--- a/theme/assets/style.css
+++ b/theme/assets/style.css
@@ -1,0 +1,9 @@
+/* Placeholder CSS for the Shopify theme */
+.site-header, .site-footer {
+  padding: 20px;
+}
+.main-nav ul {
+  list-style: none;
+  display: flex;
+  gap: 10px;
+}

--- a/theme/config/settings_schema.json
+++ b/theme/config/settings_schema.json
@@ -1,0 +1,13 @@
+[
+  {
+    "name": "General",
+    "settings": [
+      {
+        "type": "text",
+        "id": "hero_title",
+        "label": "Hero Title",
+        "default": "Welcome"
+      }
+    ]
+  }
+]

--- a/theme/layout/theme.liquid
+++ b/theme/layout/theme.liquid
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>{{ page_title }}</title>
+  {{ content_for_header }}
+  {{ 'style.css' | asset_url | stylesheet_tag }}
+</head>
+<body>
+  {% section 'header' %}
+  {{ content_for_layout }}
+  {% section 'footer' %}
+</body>
+</html>

--- a/theme/sections/footer.liquid
+++ b/theme/sections/footer.liquid
@@ -1,0 +1,16 @@
+{% comment %}Basic footer converted from static HTML{% endcomment %}
+<footer class="site-footer">
+  <div class="footer-menu">
+    <ul>
+      <li><a href="/pages/no-brand-affiliation">No Brand Affiliation</a></li>
+      <li><a href="/apps/order-tracking">Tracking</a></li>
+      <li><a href="/pages/moddys-custom-watches-warranty-policy">Warranty Policy</a></li>
+      <li><a href="/pages/seiko-moddys-watch-care">Watch Care</a></li>
+      <li><a href="/pages/policies">Policies</a></li>
+    </ul>
+  </div>
+  <div class="footer-social">
+    <a href="https://www.facebook.com/SeikoModdysEU/" target="_blank" rel="noopener">Facebook</a>
+    <a href="https://www.instagram.com/moddys.watch" target="_blank" rel="noopener">Instagram</a>
+  </div>
+</footer>

--- a/theme/sections/header.liquid
+++ b/theme/sections/header.liquid
@@ -1,0 +1,12 @@
+{% comment %}Basic header converted from static HTML{% endcomment %}
+<header class="site-header">
+  <h1 class="site-logo"><a href="{{ shop.url }}">{{ shop.name }}</a></h1>
+  <nav class="main-nav">
+    <ul>
+      <li><a href="/collections/all">Shop</a></li>
+      <li><a href="/collections/configurator">Configurator</a></li>
+      <li><a href="/blogs/news">News</a></li>
+      <li><a href="/pages/policies">Policies</a></li>
+    </ul>
+  </nav>
+</header>

--- a/theme/templates/404.liquid
+++ b/theme/templates/404.liquid
@@ -1,0 +1,2 @@
+<h1>Page not found</h1>
+<p>The page you were looking for does not exist.</p>

--- a/theme/templates/article.liquid
+++ b/theme/templates/article.liquid
@@ -1,0 +1,2 @@
+<h1>{{ article.title }}</h1>
+{{ article.content }}

--- a/theme/templates/blog.liquid
+++ b/theme/templates/blog.liquid
@@ -1,0 +1,6 @@
+<h1>{{ blog.title }}</h1>
+{% for article in blog.articles %}
+  <div>
+    <a href="{{ article.url }}">{{ article.title }}</a>
+  </div>
+{% endfor %}

--- a/theme/templates/cart.liquid
+++ b/theme/templates/cart.liquid
@@ -1,0 +1,5 @@
+<h1>Your cart</h1>
+{{ cart.items_count }} items
+{% form 'cart', cart %}
+  <button type="submit">Update</button>
+{% endform %}

--- a/theme/templates/collection.liquid
+++ b/theme/templates/collection.liquid
@@ -1,0 +1,6 @@
+<h1>{{ collection.title }}</h1>
+{% for product in collection.products %}
+  <div>
+    <a href="{{ product.url }}">{{ product.title }}</a>
+  </div>
+{% endfor %}

--- a/theme/templates/index.liquid
+++ b/theme/templates/index.liquid
@@ -1,0 +1,2 @@
+<h2>{{ settings.hero_title }}</h2>
+<p>Welcome to {{ shop.name }}.</p>

--- a/theme/templates/page.liquid
+++ b/theme/templates/page.liquid
@@ -1,0 +1,2 @@
+<h1>{{ page.title }}</h1>
+{{ page.content }}

--- a/theme/templates/product.liquid
+++ b/theme/templates/product.liquid
@@ -1,0 +1,5 @@
+<h1>{{ product.title }}</h1>
+{{ product.description }}
+{% form 'product', product %}
+  <button type="submit">Add to cart</button>
+{% endform %}

--- a/theme/templates/search.liquid
+++ b/theme/templates/search.liquid
@@ -1,0 +1,11 @@
+<h1>Search</h1>
+{% if search.performed %}
+  <p>{{ search.results_count }} results for '{{ search.terms }}'</p>
+  {% for item in search.results %}
+    <div>
+      <a href="{{ item.url }}">{{ item.title }}</a>
+    </div>
+  {% endfor %}
+{% else %}
+  <p>Use the search bar to find products.</p>
+{% endif %}


### PR DESCRIPTION
## Summary
- simplify theme.liquid layout with header and footer sections
- add basic header and footer section templates
- create simple templates for products, collections, blogs, articles, pages, cart and search
- provide placeholder CSS
- update README

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_687dd662893c833283fdb88ec54b8fc9