### PR TITLE
Add dest option and skip POST.html in converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ This repository contains the downloaded static version of the site and a lightwe
 To quickly convert remaining static HTML files into Liquid templates, run:
 
 ```bash
-python scripts/convert_html_to_liquid.py
+python scripts/convert_html_to_liquid.py [--dest DIR]
 ```
 
-Generated templates will be placed in `theme/templates/generated/`.
+Generated templates will be placed in `theme/templates/generated/` by default.
+Use `--dest` to specify a different output directory.
 


### PR DESCRIPTION
## Summary
- document html conversion helper script
- add optional destination directory argument
- skip `POST.html` files when generating templates
- document `--dest` usage in README

## Testing
- `python -m py_compile scripts/convert_html_to_liquid.py`


------
https://chatgpt.com/codex/tasks/task_e_687e7902186483328b5d14539063d4b4